### PR TITLE
Https support changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.6.15'
+          python-version: '3.8.16'
       - name: install dependencies
         run: |
             python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.6.2
+FROM python:3.8.16
 
 ENV SOLR_HOST=ec2-3-143-113-50.us-east-2.compute.amazonaws.com
 ENV SOLR_PORT=8993
 ENV SOLR_COLLECTION=bdsdump
+ENV HTTPS=True
 
 RUN mkdir /code /code/src /code/bds_api
 ADD requirements.txt run.sh setup.py logging.conf /code/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker build -t bds/search-service .
 docker run -p 8484:8080 -e SOLR_HOST=my_host -e SOLR_PORT=my_port -e SOLR_COLLECTION=bdsdump -e HTTPS=False -it bds/search-service 
 ```
 
-_(Default value of the `HTTPS` parameter is `True`, so please set it based on your environment)_ 
+_(Default value of the `HTTPS` parameter is `True`, so please set it based on your deployment environment configuration. If your deployment environment is not https, setting HTTPS=True will cause swagger interface to crash))_ 
 
 If environment variables are not given to the run command, default values will be first read from the Dockerfile then from the [configuration](src/config/search_config.ini) file.
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ To build the service, please run the following commands in the project root fold
 ```
 docker build -t bds/search-service .
 
-docker run -p 8484:8080 -e SOLR_HOST=my_host -e SOLR_PORT=my_port -e SOLR_COLLECTION=bdsdump -it bds/search-service 
+docker run -p 8484:8080 -e SOLR_HOST=my_host -e SOLR_PORT=my_port -e SOLR_COLLECTION=bdsdump -e HTTPS=False -it bds/search-service 
 ```
+
+_(Default value of the `HTTPS` parameter is `True`, so please set it based on your environment)_ 
 
 If environment variables are not given to the run command, default values will be first read from the Dockerfile then from the [configuration](src/config/search_config.ini) file.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,7 +96,8 @@ docker build -t bds/search-service .
 
 To run the built Docker image:
 ```
-docker run -p 8484:8080 -e SOLR_HOST=$SERVER_IP -e SOLR_PORT=8983 -e SOLR_COLLECTION=bdsdump -it bds/search-service 
+docker run -p 8484:8080 -e SOLR_HOST=$SERVER_IP -e SOLR_PORT=8983 -e SOLR_COLLECTION=bdsdump -e HTTPS=True -it bds/search-service 
 ```
+_(Default value of the `HTTPS` parameter is `True`, so please set it based on your environment. If your deployment environment is not https, setting HTTPS=True will cause swagger interface to crash)_ 
 
 Now you can browse the API [Swagger interface](http://SERVER_IP:8484/bds/) and run one of the example queries. Such as: http://SERVER_IP:8484/bds/api/autocomplete?query=L5%2F6%2520NP

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 neo4j==4.2.1
-requests
-Flask==1.1.1
-flask-restplus==0.13
-Werkzeug==0.16.0
+requests==2.28.2
+flask==2.1.2
+flask-restx>=0.5.1
+werkzeug==2.0.2
 pyyaml
-itsdangerous==2.0.1
+itsdangerous==2.1.2

--- a/src/bds_api/app.py
+++ b/src/bds_api/app.py
@@ -20,7 +20,7 @@ def initialize_app(flask_app):
 def main():
     initialize_app(app)
     app.run(host="0.0.0.0", port=8080, debug=settings.FLASK_DEBUG)
-    # TODO fix me, testing https here (add pyopenssl to requirements)
+    # TODO just testing https here (add pyopenssl to requirements.txt)
     # app.run(host="0.0.0.0", port=8080, debug=settings.FLASK_DEBUG, ssl_context='adhoc')
 
 

--- a/src/bds_api/app.py
+++ b/src/bds_api/app.py
@@ -11,16 +11,7 @@ app.wsgi_app = ProxyFix(app.wsgi_app)
 blueprint = Blueprint('bds', __name__, url_prefix='/bds')
 
 
-def configure_app(flask_app):
-    # flask_app.config['SERVER_NAME'] = settings.FLASK_SERVER_NAME
-    flask_app.config['SWAGGER_UI_DOC_EXPANSION'] = settings.RESTPLUS_SWAGGER_UI_DOC_EXPANSION
-    flask_app.config['RESTPLUS_VALIDATE'] = settings.RESTPLUS_VALIDATE
-    flask_app.config['RESTPLUS_MASK_SWAGGER'] = settings.RESTPLUS_MASK_SWAGGER
-    flask_app.config['ERROR_404_HELP'] = settings.RESTPLUS_ERROR_404_HELP
-
-
 def initialize_app(flask_app):
-    configure_app(flask_app)
     api.init_app(blueprint)
     api.add_namespace(api_namespace)
     flask_app.register_blueprint(blueprint)
@@ -29,6 +20,8 @@ def initialize_app(flask_app):
 def main():
     initialize_app(app)
     app.run(host="0.0.0.0", port=8080, debug=settings.FLASK_DEBUG)
+    # TODO fix me, testing https here (add pyopenssl to requirements)
+    # app.run(host="0.0.0.0", port=8080, debug=settings.FLASK_DEBUG, ssl_context='adhoc')
 
 
 if __name__ == '__main__':

--- a/src/bds_api/endpoints/parser.py
+++ b/src/bds_api/endpoints/parser.py
@@ -1,4 +1,4 @@
-from flask_restplus import reqparse
+from flask_restx import reqparse
 
 search_arguments = reqparse.RequestParser()
 search_arguments.add_argument('query', type=str, action="append", required=True)

--- a/src/bds_api/endpoints/search_service.py
+++ b/src/bds_api/endpoints/search_service.py
@@ -3,7 +3,7 @@ import requests
 import ast
 import logging
 from flask import request
-from flask_restplus import Resource
+from flask_restx import Resource
 from bds_api.restplus import api
 from bds_api.endpoints.search_config import search_config, autocomplete_config
 from bds_api.exception.api_exception import BDSApiException

--- a/src/bds_api/restplus.py
+++ b/src/bds_api/restplus.py
@@ -1,13 +1,27 @@
+import os
 import logging
 from http import HTTPStatus
 
-from flask_restplus import Api
+from flask import url_for
+from flask_restx import Api
 from bds_api.exception.api_exception import BDSApiException
 
 log = logging.getLogger(__name__)
 
-api = Api(version='0.0.1', title='BDS Ontology RESTful API',
-          description='Brain Data Standards Ontology restful API that wraps search and query endpoints.')
+
+# added for https bugfix https://github.com/noirbizarre/flask-restplus/issues/565
+class SearchApi(Api):
+    @property
+    def specs_url(self):
+        """Monkey patch for HTTPS"""
+        is_https = os.getenv("HTTPS", 'True').lower() in ('true', '1', 't')
+        scheme = 'https' if is_https else 'http'
+        log.info("Production mode is: " + scheme)
+        return url_for(self.endpoint('specs'), _external=True, _scheme=scheme)
+
+
+api = SearchApi(version='0.0.1', title='BDS Ontology RESTful API',
+                description='Brain Data Standards Ontology restful API that wraps search and query endpoints.')
 
 
 @api.errorhandler


### PR DESCRIPTION
Swagger interface is still crasing on https servers. So applied thee changes:
- Migrated from restplus to restx 
- Upgraded all dependency versions and Docker python version to 3.6 -> 3.8
- Added 'HTTPS' environment variable to workaround this bug: https://github.com/noirbizarre/flask-restplus/issues/565